### PR TITLE
Refactor file upload limits and improve clarity

### DIFF
--- a/app/(root)/ask/ask-form.tsx
+++ b/app/(root)/ask/ask-form.tsx
@@ -79,7 +79,7 @@ const AskForm: FC<AskFormProps> = ({ user }) => {
             </div>
             <div className={'space-y-4 md:col-span-3'}>
               <RHFFormField control={control} name={'message'} formKey={'message'} type={'textarea'} />
-              <RHFFormDropzone control={control} name={'attachments'} formKey={'attachments'} images={attachments} form={form} folderName={'contact-and-enquiry'} maxLimit={GLOBAL.LIMIT.MAX_IMAGE_ATTACHMENT_ENQUIRY} />
+              <RHFFormDropzone control={control} name={'attachments'} formKey={'attachments'} images={attachments} form={form} folderName={'contact-and-enquiry'} maxLimitQty={GLOBAL.LIMIT.MAX_IMAGE_ATTACHMENT_ENQUIRY} maxLimitFileSize={GLOBAL.LIMIT.MAX_UPLOAD_SIZE_ENQUIRY} />
               <div className={'flex justify-end'}>
                 <TapeBtn label={isPending ? <EllipsisLoader /> : transl('send_message.label')} className={'w-full md:w-[300px] texture-4-bg'} disabled={submitted} />
               </div>

--- a/component/admin/form/product-form.tsx
+++ b/component/admin/form/product-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FC, Fragment, useEffect } from 'react'
+import { GLOBAL } from 'hgss'
 import { PATH_DIR } from 'hgss-dir'
 import { useRouter } from 'next/navigation'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -112,7 +113,7 @@ const ProductForm: FC<ProductForm> = ({ type, product, productId }) => {
             <SpecificationField fields={fields} register={register} onClick={() => append('')} remove={remove} />
           </div>
           <div className={"upload-field flex flex-col md:flex-row gap-4"}>
-            <RHFFormDropzone control={control} name={'images'} formKey={'images'} images={images} form={form} folderName={'product'} />
+            <RHFFormDropzone control={control} name={'images'} formKey={'images'} images={images} form={form} folderName={'product'} maxLimitFileSize={GLOBAL.LIMIT.MAX_UPLOAD_SIZE_PRODUCT} maxLimitQty={GLOBAL.LIMIT.MAX_PHOTO_QTY_PRODUCT} />
           </div>
           <div className={"upload-field gap-4 h-auto"}>
             <RHFFormField control={control} name={'description'} formKey={'description'} type={'textarea'} withWrapper={false} />

--- a/component/shared/rhf/rhf-form-image-upload.tsx
+++ b/component/shared/rhf/rhf-form-image-upload.tsx
@@ -1,18 +1,18 @@
 "use client"
 
 import { useState } from 'react'
-import { z, ZodSchema } from 'zod'
-import { en } from 'public/locale'
 import { GLOBAL } from 'hgss'
-import { Control, Path, UseFormReturn } from 'react-hook-form'
+import { PATH_DIR } from 'hgss-dir'
 import Image from 'next/image'
+import { en } from 'public/locale'
+import { z, ZodSchema } from 'zod'
+import { Control, Path, UseFormReturn } from 'react-hook-form'
 import { useToast } from 'hook'
 import { X, ImageUp } from 'lucide-react'
 import { deleteImage } from 'lib/action'
-import { cn } from 'lib'
+import { cn, transl } from 'lib'
 import { FormField, FormLabel, FormMessage, FormItem, FormControl } from 'component/ui/form'
 import { Card, CardContent } from 'component/ui/card'
-import { PATH_DIR } from 'hgss-dir'
 
 type FormKeyLocale = keyof typeof en.form
 
@@ -39,9 +39,9 @@ const RHFFormImageUpload = <TSchema extends ZodSchema>({ control, name, image, f
     const result       = await deleteImage({ currentImages: currentImage })
     if (result?.success) {
       form.setValue(name, '' as SetFieldName)
-      toast({ description: en.success.file_deleted })
+      toast({ description: transl('success.file_deleted') })
     } else {
-      toast({ variant: 'destructive', description: en.error.unable_delete })
+      toast({ variant: 'destructive', description: transl('error.unable_delete') })
     }
   }
 
@@ -80,12 +80,12 @@ const RHFFormImageUpload = <TSchema extends ZodSchema>({ control, name, image, f
           return copy
         })
       } else {
-        toast({ variant: 'destructive', description: en.error.unable_upload })
+        toast({ variant: 'destructive', description: transl('error.unable_upload') })
       }
     }
 
     xhr.onerror = () => {
-      toast({ variant: 'destructive', description: en.error.unable_upload })
+      toast({ variant: 'destructive', description: transl('error.unable_upload') })
     }
 
     xhr.open('POST', PATH_DIR.UPLOAD)
@@ -98,7 +98,7 @@ const RHFFormImageUpload = <TSchema extends ZodSchema>({ control, name, image, f
       name={name}
       render={() => (
         <FormItem className={'w-full'}>
-          {withLabel && <FormLabel>{en.form[formKey].label}</FormLabel>}
+          {withLabel && <FormLabel>{transl(`form.${formKey}.label`)}</FormLabel>}
           <Card>
             <CardContent className={'space-y-2 mt-2 '}>
                   {image && (
@@ -116,7 +116,7 @@ const RHFFormImageUpload = <TSchema extends ZodSchema>({ control, name, image, f
                     {!image && (
                       <div className="flex flex-col items-center justify-center">
                         <ImageUp size={40} />
-                        {en.upload.description}
+                        {transl('upload.description')}
                       </div>
                     )}
                     <input disabled={image !== ''} type="file" accept="image/*" onChange={(e) => handleUpload(e)} className={'hidden'} />

--- a/component/shared/rhf/rhf-form-image-upload.tsx
+++ b/component/shared/rhf/rhf-form-image-upload.tsx
@@ -49,11 +49,11 @@ const RHFFormImageUpload = <TSchema extends ZodSchema>({ control, name, image, f
     const file = e.target.files?.[0]
     if (!file) return
 
-    const maxLimit = GLOBAL.LIMIT.MAX_UPLOAD_SIZE_GALLERY * 1024 * 1024
+    const maxFileSizeLimit = GLOBAL.LIMIT.MAX_UPLOAD_SIZE_GALLERY * 1024 * 1024
 
-    if (file.size > maxLimit) {
-      toast({ variant: 'destructive', description: `File exceeds the ${GLOBAL.LIMIT.MAX_UPLOAD_SIZE_GALLERY}MB limit` })
-      throw new Error(`File exceeds the ${GLOBAL.LIMIT.MAX_UPLOAD_SIZE_GALLERY}MB limit`)
+    if (file.size > maxFileSizeLimit) {
+      toast({ variant: 'destructive', description: `File exceeds the ${maxFileSizeLimit}MB limit` })
+      throw new Error(`File exceeds the ${maxFileSizeLimit}MB limit`)
     }
 
     const formData = new FormData()

--- a/config/global.config.ts
+++ b/config/global.config.ts
@@ -19,7 +19,11 @@ export const GLOBAL = {
                             USER_ORDERS                 : 10,
                             PRODUCT_SPECS_MAX           : 5,
                             MAX_UPLOAD_SIZE_GALLERY     : 7,                                           // MB,
+                            MAX_UPLOAD_SIZE_ENQUIRY     : 7,                                           // MB,
+                            MAX_UPLOAD_SIZE_PRODUCT     : 7,                                           // MB,
                             MAX_IMAGE_ATTACHMENT_ENQUIRY: 4,
+                            MAX_PHOTO_QTY_GALLERY       : 5,
+                            MAX_PHOTO_QTY_PRODUCT       : 5,
                             MAX_ALLOWED_ENQUIRY         : 10,
                             WAIT_TIME_ENQUIRY           : 24 * 60 * 60 * 1000 * 7,                     // MB,
                             RESET_PASSWORD_LINK_EXPIRY  : new Date(Date.now() + 3 * 60 * 60 * 1000),   // HOUR


### PR DESCRIPTION
Enhance clarity in property names and align file size limits for image uploads across forms. Clean up locale translations and ensure consistent handling of file size and quantity limits in the dropzone component.